### PR TITLE
Implement schedule parser prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
-# snapcalendar
+# SnapCalendar
+
+This project contains a very small prototype for a calendar web page. Users can
+enter their schedule in a free-text box and have the events parsed into a list.
+A preferences section lets users configure how many minutes in advance they want
+reminders for certain categories of events.
+
+## Usage
+
+Open `web/index.html` in a browser. Type your events with one per line using the
+format:
+
+```
+YYYY-MM-DD HH:MM category description
+```
+
+For example:
+
+```
+2024-06-10 08:00 school Math class
+2024-06-10 17:30 soccer Practice at the field
+```
+
+Set reminder preferences in the form `category:minutes`. Multiple categories can
+be separated by commas, e.g. `school:60,soccer:30`. When you press **Process
+Schedule**, the events will be shown along with the time you will be reminded.
+

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>SnapCalendar</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <h1>SnapCalendar</h1>
+    <p>Type your schedule below. Each line should be formatted as:<br>
+    <code>YYYY-MM-DD HH:MM category description</code></p>
+    <textarea id="scheduleInput" rows="6" cols="60" placeholder="2024-06-10 08:00 school Math class"></textarea>
+    <br>
+    <button id="processButton">Process Schedule</button>
+
+    <h2>Events</h2>
+    <ul id="eventsList"></ul>
+
+    <h2>Preferences</h2>
+    <p>Set early reminder minutes per category (e.g., <code>school:60,soccer:30</code>)</p>
+    <input id="remindersInput" size="40" placeholder="category:minutes,category:minutes">
+    <button id="savePrefs">Save Preferences</button>
+
+    <script src="script.js"></script>
+</body>
+</html>

--- a/web/script.js
+++ b/web/script.js
@@ -1,0 +1,64 @@
+const scheduleInput = document.getElementById('scheduleInput');
+const processButton = document.getElementById('processButton');
+const eventsList = document.getElementById('eventsList');
+const remindersInput = document.getElementById('remindersInput');
+const savePrefsButton = document.getElementById('savePrefs');
+
+let reminders = {};
+
+function loadPrefs() {
+    const stored = localStorage.getItem('reminders');
+    if (stored) {
+        reminders = JSON.parse(stored);
+        remindersInput.value = Object.entries(reminders)
+            .map(([cat, min]) => `${cat}:${min}`).join(',');
+    }
+}
+
+function savePrefs() {
+    reminders = {};
+    remindersInput.value.split(',').forEach(pair => {
+        const [cat, min] = pair.split(':');
+        if (cat && min) {
+            reminders[cat.trim()] = parseInt(min.trim(), 10) || 0;
+        }
+    });
+    localStorage.setItem('reminders', JSON.stringify(reminders));
+}
+
+function parseSchedule(text) {
+    const events = [];
+    const lines = text.split(/\n/);
+    lines.forEach(line => {
+        const regex = /(\d{4}-\d{2}-\d{2})\s+(\d{1,2}:\d{2})\s+(\w+)\s+(.*)/;
+        const m = line.match(regex);
+        if (m) {
+            const dt = new Date(`${m[1]}T${m[2]}`);
+            events.push({ date: dt, category: m[3], description: m[4] });
+        }
+    });
+    return events;
+}
+
+function renderEvents(events) {
+    eventsList.innerHTML = '';
+    events.forEach(ev => {
+        const li = document.createElement('li');
+        const minutes = reminders[ev.category] || 0;
+        const remindAt = new Date(ev.date.getTime() - minutes * 60000);
+        li.textContent = `${ev.date.toLocaleString()} [${ev.category}] - ${ev.description} (remind at ${remindAt.toLocaleString()})`;
+        eventsList.appendChild(li);
+    });
+}
+
+processButton.addEventListener('click', () => {
+    const events = parseSchedule(scheduleInput.value);
+    renderEvents(events);
+});
+
+savePrefsButton.addEventListener('click', () => {
+    savePrefs();
+    alert('Preferences saved');
+});
+
+loadPrefs();

--- a/web/style.css
+++ b/web/style.css
@@ -1,0 +1,13 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 20px;
+}
+
+textarea {
+    width: 100%;
+    max-width: 600px;
+}
+
+#eventsList li {
+    margin-bottom: 4px;
+}


### PR DESCRIPTION
## Summary
- build a prototype calendar web interface in `web/`
- parse schedule lines into events
- allow per-category reminder settings
- document usage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852e43350e4832cab0dc236954f31b0